### PR TITLE
Исправление абсолютного пути к SadTalker

### DIFF
--- a/face/sadtalker_infer.py
+++ b/face/sadtalker_infer.py
@@ -8,7 +8,9 @@ def generate_video(input_image, input_audio, output_dir="assets/output"):
     os.makedirs(output_dir, exist_ok=True)
     output_path = os.path.join(output_dir, f"{uuid.uuid4()}.mp4")
 
-    sadtalker_path = "./SadTalker-main/inference.py"
+    sadtalker_path = os.path.join(
+        os.path.dirname(__file__), "..", "SadTalker-main", "inference.py"
+    )
     command = [
         "python",
         sadtalker_path,


### PR DESCRIPTION
## Notes
- Путь к `SadTalker-main/inference.py` теперь вычисляется на основе `__file__`, поэтому его можно вызывать из любого каталога.
- Проверена доступность пути из корня проекта и из сторонней директории.

## Testing
- `python -m py_compile face/sadtalker_infer.py`


------
https://chatgpt.com/codex/tasks/task_e_683d38aa111c8324ae1d3ebdc5934c6f