### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+TTS-dev/
+so-vits-svc-4.1-Stable/
+Wav2Lip-master/
+SadTalker-main/.git/
+__pycache__/
+assets/
+uploads/
+


### PR DESCRIPTION
## Summary
- add a project `.dockerignore` with directories that shouldn't be included in Docker build context

## Testing
- `pytest -k "nonexistent" -sv` *(fails: ModuleNotFoundError: No module named 'fsspec')*

------
https://chatgpt.com/codex/tasks/task_e_683d49adcebc8324aa712439afb4b5bd