### PR TITLE
Use sys.executable for script launches

### DIFF
--- a/face/wav2lip_infer.py
+++ b/face/wav2lip_infer.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import uuid
+import sys
 
 
 def enhance_lip_sync(video_path: str, audio_path: str, output_dir="assets/wav2lip") -> str:
@@ -11,7 +12,7 @@ def enhance_lip_sync(video_path: str, audio_path: str, output_dir="assets/wav2li
     checkpoint = os.getenv("WAV2LIP_CHECKPOINT", "checkpoints/wav2lip.pth")
     script = os.path.join(base_dir, "inference.py")
     command = [
-        "python",
+        sys.executable,
         script,
         "--checkpoint_path",
         checkpoint,

--- a/tts/sovits_infer.py
+++ b/tts/sovits_infer.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import uuid
 import shutil
+import sys
 from glob import glob
 
 
@@ -22,7 +23,7 @@ def convert_voice(input_wav: str, speaker: str, output_dir="assets/converted") -
     config_path = os.getenv("SOVITS_CONFIG", "logs/44k/config.json")
     svc_script = os.path.join(base_dir, "inference_main.py")
     command = [
-        "python",
+        sys.executable,
         svc_script,
         "-m",
         model_path,


### PR DESCRIPTION
## Summary
- replace `"python"` with `sys.executable` in Sovits and Wav2Lip helpers
- add missing imports for `sys`

## Testing
- `python -m py_compile tts/sovits_infer.py face/wav2lip_infer.py`

------
https://chatgpt.com/codex/tasks/task_e_683d76e1b5548324b6a434de5b16b559