### PR TITLE
Поддержка S3 с нейтральными переменными

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,12 @@
 CELERY_BROKER_URL=redis://localhost:6379/0
 CELERY_BACKEND_URL=redis://localhost:6379/1
 API_SECRET_KEY=your-secret-key
+S3_ACCESS_KEY_ID=your-access-key
+S3_SECRET_ACCESS_KEY=your-secret
+S3_REGION=your-region
+S3_ENDPOINT=https://storage.yandexcloud.kz
 S3_BUCKET=your-bucket
+S3_URL_BUCKET=https://storage.yandexcloud.kz/your-bucket
 SOVITS_MODEL=/path/to/sovits/model.pth
 SOVITS_CONFIG=/path/to/sovits/config.json
 SOVITS_SPK=example_spk

--- a/README.md
+++ b/README.md
@@ -83,7 +83,14 @@ uvicorn backend.api:app --reload
 Запустите сервисы, при необходимости указав переменные окружения:
 
 ```bash
-API_SECRET_KEY=<ключ> S3_BUCKET=<имя_бакета> docker compose up --build
+API_SECRET_KEY=<ключ> \
+S3_ACCESS_KEY_ID=<id> \
+S3_SECRET_ACCESS_KEY=<секрет> \
+S3_REGION=<регион> \
+S3_ENDPOINT=<endpoint> \
+S3_BUCKET=<имя_бакета> \
+S3_URL_BUCKET=<публичный_url> \
+docker compose up --build
 ```
 
 
@@ -94,7 +101,11 @@ API_SECRET_KEY=<ключ> S3_BUCKET=<имя_бакета> docker compose up --bu
 `S3_BUCKET`.
 
 * `API_SECRET_KEY` — защищает эндпоинты FastAPI. Клиент должен передавать значение в заголовке `X-API-Key`.
+* `S3_ACCESS_KEY_ID` и `S3_SECRET_ACCESS_KEY` — учетные данные для доступа к S3.
+* `S3_REGION` — регион S3.
+* `S3_ENDPOINT` — URL эндпоинта S3 (например, `https://storage.yandexcloud.kz`).
 * `S3_BUCKET` — имя бакета S3 для загрузки готовых видео. Если переменная не задана, файлы останутся в контейнере.
+* `S3_URL_BUCKET` — базовый публичный URL бакета для формирования ссылок на загруженные файлы.
 
 По умолчанию будут подняты контейнеры FastAPI, Celery и Redis.
 ## Запуск тестов

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -18,7 +18,22 @@ BACKEND_URL = os.getenv("CELERY_BACKEND_URL", "redis://localhost:6379/0")
 celery_app = Celery("voice_video_tasks", broker=BROKER_URL, backend=BACKEND_URL)
 
 s3_bucket = os.getenv("S3_BUCKET")
-s3_client = boto3.client("s3") if s3_bucket else None
+s3_endpoint = os.getenv("S3_ENDPOINT")
+s3_region = os.getenv("S3_REGION")
+s3_access_key = os.getenv("S3_ACCESS_KEY_ID")
+s3_secret_key = os.getenv("S3_SECRET_ACCESS_KEY")
+s3_url_bucket = os.getenv("S3_URL_BUCKET")
+s3_client = (
+    boto3.client(
+        "s3",
+        endpoint_url=s3_endpoint,
+        region_name=s3_region,
+        aws_access_key_id=s3_access_key,
+        aws_secret_access_key=s3_secret_key,
+    )
+    if s3_bucket
+    else None
+)
 @celery_app.task
 def generate_video_task(image_path: str, text: str, language: str, speaker_audio: str | None = None):
     tts_audio = generate_tts(text, speaker_audio, language)
@@ -43,7 +58,10 @@ def generate_video_task(image_path: str, text: str, language: str, speaker_audio
         try:
             logging.info("Uploading %s to S3 bucket %s", final_video, s3_bucket)
             s3_client.upload_file(final_video, s3_bucket, key)
-            url = f"https://{s3_bucket}.s3.amazonaws.com/{key}"
+            if s3_url_bucket:
+                url = f"{s3_url_bucket}/{key}"
+            else:
+                url = f"https://{s3_bucket}.s3.amazonaws.com/{key}"
             logging.info("File uploaded successfully: %s", url)
             return url
         except Exception:


### PR DESCRIPTION
## Summary
- убраны упоминания AWS, переменные названы `S3_*`
- `tasks.py` передаёт параметры доступа в `boto3.client`
- `.env.example` и README обновлены

## Testing
- `pytest -q` *(ошибка: отсутствуют зависимости)*


------
https://chatgpt.com/codex/tasks/task_e_683db827126883249816ebb715e56e8b