### PR TITLE
Fix TTS install and compose env

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 # Exclude third-party source directories and temporary folders from Docker context
 
-TTS-dev/
 so-vits-svc-4.1-Stable/
 Wav2Lip-master/
 SadTalker-main/.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+# Install the local TTS dependency
+RUN pip install ./TTS-dev
 
 # Download pretrained models
 RUN bash SadTalker-main/scripts/download_models.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       - CELERY_BACKEND_URL=redis://redis:6379/0
       - API_SECRET_KEY=${API_SECRET_KEY}
       - S3_BUCKET=${S3_BUCKET}
+      - S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
+      - S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}
+      - S3_REGION=${S3_REGION}
+      - S3_ENDPOINT=${S3_ENDPOINT}
+      - S3_URL_BUCKET=${S3_URL_BUCKET}
     volumes:
       - ./models:/app/models
       - ./assets:/app/assets
@@ -26,6 +31,11 @@ services:
       - CELERY_BACKEND_URL=redis://redis:6379/0
       - API_SECRET_KEY=${API_SECRET_KEY}
       - S3_BUCKET=${S3_BUCKET}
+      - S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
+      - S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}
+      - S3_REGION=${S3_REGION}
+      - S3_ENDPOINT=${S3_ENDPOINT}
+      - S3_URL_BUCKET=${S3_URL_BUCKET}
     volumes:
       - ./models:/app/models
       - ./assets:/app/assets


### PR DESCRIPTION
## Summary
- include `TTS-dev` in Docker build context
- install local `TTS-dev` inside Docker image
- expose S3 credentials in docker-compose services

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fsspec')*


------
https://chatgpt.com/codex/tasks/task_e_683e952103948324a630ba7c453f6361