### PR TITLE
Fix Celery backend default URL

### DIFF
--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -13,7 +13,7 @@ import os
 
 
 BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
-BACKEND_URL = os.getenv("CELERY_BACKEND_URL", "redis://localhost:6379/0")
+BACKEND_URL = os.getenv("CELERY_BACKEND_URL", "redis://localhost:6379/1")
 
 celery_app = Celery("voice_video_tasks", broker=BROKER_URL, backend=BACKEND_URL)
 


### PR DESCRIPTION
## Summary
- update default Celery result backend URL to match `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fsspec')*

------
https://chatgpt.com/codex/tasks/task_e_683e9524f8108324812124894183551b