### PR TITLE
Fix Celery backend URL in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build: .
     environment:
       - CELERY_BROKER_URL=redis://redis:6379/0
-      - CELERY_BACKEND_URL=redis://redis:6379/0
+      - CELERY_BACKEND_URL=redis://redis:6379/1
       - API_SECRET_KEY=${API_SECRET_KEY}
       - S3_BUCKET=${S3_BUCKET}
       - S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
@@ -28,7 +28,7 @@ services:
     command: celery -A backend.tasks worker --loglevel=info
     environment:
       - CELERY_BROKER_URL=redis://redis:6379/0
-      - CELERY_BACKEND_URL=redis://redis:6379/0
+      - CELERY_BACKEND_URL=redis://redis:6379/1
       - API_SECRET_KEY=${API_SECRET_KEY}
       - S3_BUCKET=${S3_BUCKET}
       - S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}


### PR DESCRIPTION
## Summary
- point CELERY_BACKEND_URL in docker-compose to Redis DB 1
- keep defaults consistent with .env.example and backend/tasks.py

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_683eab39f9288324ac7a70009734adf3