### PR TITLE
Relax numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ gradio
 torch
 torchaudio
 ffmpeg-python
-numpy==1.23.4
+numpy>=1.22,<1.27
 Pillow
 scipy==1.10.1
 transformers>=4.33.0


### PR DESCRIPTION
## Summary
- relax `numpy` version pin to allow versions from `1.22` to `<1.27`

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683eab3f8e98832485e3daf8078db39a