### PR TITLE
Update SciPy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ torchaudio
 ffmpeg-python
 numpy>=1.22,<1.27
 Pillow
-scipy==1.10.1
+scipy>=1.11.2
 transformers>=4.33.0
 fastapi
 uvicorn


### PR DESCRIPTION
## Summary
- upgrade `scipy` requirement to a compatible `>=1.11.2`

## Testing
- `pytest -q tests/test_api.py` *(fails: `ModuleNotFoundError: No module named 'fastapi'`)*
- `pip install -r requirements.txt` *(fails: `No route to host`)*

------
https://chatgpt.com/codex/tasks/task_e_683ec989ff7c8324a549820d0fde74dc