### PR TITLE
Remove deprecated compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   redis:
     image: redis:7


### PR DESCRIPTION
## Summary
- remove Compose file version declaration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_683ec98c134c8324bbcf428df5f4ebb1