### PR TITLE
Refactor tasks to lazy import heavy modules

### DIFF
--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1,8 +1,4 @@
 from celery import Celery
-from tts.xtts_infer import generate_tts
-from tts.sovits_infer import convert_voice
-from face.sadtalker_infer import generate_video
-from face.wav2lip_infer import enhance_lip_sync
 
 import logging
 
@@ -36,6 +32,10 @@ s3_client = (
 )
 @celery_app.task
 def generate_video_task(image_path: str, text: str, language: str, speaker_audio: str | None = None):
+    from tts.xtts_infer import generate_tts
+    from tts.sovits_infer import convert_voice
+    from face.sadtalker_infer import generate_video
+    from face.wav2lip_infer import enhance_lip_sync
     tts_audio = generate_tts(text, speaker_audio, language)
 
     speaker = os.getenv("SOVITS_SPK", "default")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,26 @@
 import io
 import os
+import sys
+import types
 from fastapi.testclient import TestClient
+
+sys.modules.setdefault(
+    "tts.xtts_infer",
+    types.SimpleNamespace(generate_tts=lambda *a, **k: "tts.wav"),
+)
+sys.modules.setdefault(
+    "tts.sovits_infer",
+    types.SimpleNamespace(convert_voice=lambda *a, **k: "vc.wav"),
+)
+sys.modules.setdefault(
+    "face.sadtalker_infer",
+    types.SimpleNamespace(generate_video=lambda *a, **k: "video.mp4"),
+)
+sys.modules.setdefault(
+    "face.wav2lip_infer",
+    types.SimpleNamespace(enhance_lip_sync=lambda *a, **k: "video.mp4"),
+)
+
 import backend.api as api
 
 class DummyTask:


### PR DESCRIPTION
## Summary
- move resource-intensive imports inside `generate_video_task`
- inject dummy inference modules in tests to avoid loading heavy dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_683edecac8908324adb9c74317769431