### PR TITLE
Improve cleanup on sovits failure

### DIFF
--- a/tests/test_sovits_infer.py
+++ b/tests/test_sovits_infer.py
@@ -1,0 +1,37 @@
+import os
+import subprocess
+import uuid
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import tts.sovits_infer as sovits
+from tts.sovits_infer import convert_voice
+
+
+def test_convert_voice_process_failure(monkeypatch, tmp_path):
+    # create dummy wav file
+    wav_in = tmp_path / "in.wav"
+    wav_in.write_bytes(b"0")
+
+    # use predictable uuid
+    monkeypatch.setattr(uuid, "uuid4", lambda: "testid")
+
+    # simulate failure of subprocess.run
+    def fake_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd=args[0])
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    base_dir = os.path.join(os.path.dirname(sovits.__file__), "..", "so-vits-svc-4.1-Stable")
+    raw_dir = os.path.join(base_dir, "raw")
+    temp_input = os.path.join(raw_dir, "testid.wav")
+    # ensure clean state
+    if os.path.exists(temp_input):
+        os.remove(temp_input)
+
+    with pytest.raises(RuntimeError, match="so-vits-svc failed"):
+        convert_voice(str(wav_in), "spk")
+
+    assert not os.path.exists(temp_input)

--- a/tts/sovits_infer.py
+++ b/tts/sovits_infer.py
@@ -34,7 +34,13 @@ def convert_voice(input_wav: str, speaker: str, output_dir="assets/converted") -
         "-s",
         speaker,
     ]
-    subprocess.run(command, check=True, cwd=base_dir)
+    try:
+        subprocess.run(command, check=True, cwd=base_dir)
+    except Exception as e:
+        raise RuntimeError(f"so-vits-svc failed: {e}") from e
+    finally:
+        if os.path.exists(temp_input):
+            os.remove(temp_input)
 
     candidates = sorted(glob(os.path.join(results_dir, f"{os.path.splitext(temp_name)[0]}_*")))
     if not candidates:
@@ -42,5 +48,4 @@ def convert_voice(input_wav: str, speaker: str, output_dir="assets/converted") -
     converted = candidates[-1]
     output_path = os.path.join(output_dir, os.path.basename(converted))
     shutil.move(converted, output_path)
-    os.remove(temp_input)
     return output_path


### PR DESCRIPTION
## Summary
- ensure temporary wav file is removed when sovits call fails
- raise informative error if sovits subprocess fails
- cover failure path in tests

## Testing
- `pytest tests/test_sovits_infer.py::test_convert_voice_process_failure -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_683edeca962c83249a621faad8f068ec