### PR TITLE
Fix SadTalker command execution

### DIFF
--- a/face/sadtalker_infer.py
+++ b/face/sadtalker_infer.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import uuid
+import sys
 
 
 def generate_video(input_image, input_audio, output_dir="assets/output"):
@@ -12,7 +13,7 @@ def generate_video(input_image, input_audio, output_dir="assets/output"):
         os.path.dirname(__file__), "..", "SadTalker-main", "inference.py"
     )
     command = [
-        "python",
+        sys.executable,
         sadtalker_path,
         "--driven_audio",
         input_audio,

--- a/tests/test_sadtalker_command.py
+++ b/tests/test_sadtalker_command.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+import face.sadtalker_infer as si
+
+
+def test_command_uses_sys_executable(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run(cmd, check=True):
+        captured['cmd'] = cmd
+    monkeypatch.setattr(si.subprocess, 'run', fake_run)
+    monkeypatch.setattr(si.os.path, 'exists', lambda path: False)
+    monkeypatch.setattr(si.os, 'replace', lambda src, dst: None)
+
+    si.generate_video('img.png', 'audio.wav', output_dir=str(tmp_path))
+
+    expected_sadtalker = os.path.join(os.path.dirname(si.__file__), '..', 'SadTalker-main', 'inference.py')
+    expected_command = [
+        sys.executable,
+        expected_sadtalker,
+        '--driven_audio',
+        'audio.wav',
+        '--source_image',
+        'img.png',
+        '--result_dir',
+        str(tmp_path),
+        '--enhancer',
+        'gfpgan',
+        '--still',
+        '--preprocess',
+        'full',
+    ]
+    assert captured['cmd'] == expected_command


### PR DESCRIPTION
## Summary
- use `sys.executable` instead of string "python" to invoke SadTalker
- import `sys` in module
- add test to verify command building

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_683edec8eb588324b8c9a59d6eae11a6