### PR TITLE
Lazy initialize TTS model

### DIFF
--- a/tts/xtts_infer.py
+++ b/tts/xtts_infer.py
@@ -2,14 +2,23 @@ from TTS.api import TTS
 import os
 import uuid
 
-tts = TTS(model_name="tts_models/multilingual/multi-dataset/xtts_v2", progress_bar=False)
+# Модель инициализируется лениво при первом вызове generate_tts
+tts_model = None
 
 
 def generate_tts(text, speaker_wav_path, language, output_dir="assets"):
     """Generate speech from text and return path to the WAV file."""
+    global tts_model
+
+    if tts_model is None:
+        tts_model = TTS(
+            model_name="tts_models/multilingual/multi-dataset/xtts_v2",
+            progress_bar=False,
+        )
+
     os.makedirs(output_dir, exist_ok=True)
     output_path = os.path.join(output_dir, f"{uuid.uuid4()}.wav")
-    tts.tts_to_file(
+    tts_model.tts_to_file(
         text=text,
         speaker_wav=speaker_wav_path,
         language=language,


### PR DESCRIPTION
## Summary
- load the XTTS model lazily on first use

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_683edec79bbc8324abed5d0cfdb5e1b9