### PR TITLE
Fix SadTalker invocation

### DIFF
--- a/face/sadtalker_infer.py
+++ b/face/sadtalker_infer.py
@@ -1,18 +1,35 @@
 import os
 import subprocess
+import sys
 
-def generate_video(input_image, input_audio, output_path="assets/output/result.mp4"):
-    sadtalker_path = "./SadTalker/inference.py"
+def generate_video(input_image: str, input_audio: str, output_path: str = "assets/output/result.mp4") -> str:
+    """Запустить SadTalker и вернуть путь к полученному видео."""
+
+    output_dir = os.path.dirname(output_path)
+    os.makedirs(output_dir, exist_ok=True)
+
+    default_root = os.path.join(os.path.dirname(__file__), "..", "SadTalker-main")
+    base_dir = os.environ.get("SADTALKER_ROOT", default_root)
+    sadtalker_path = os.path.join(base_dir, "inference.py")
+
     command = [
-        "python", sadtalker_path,
-        "--driven_audio", input_audio,
-        "--source_image", input_image,
-        "--result_dir", "assets/output",
-        "--enhancer", "gfpgan",
-        "--still", "--preprocess", "full"
+        sys.executable,
+        sadtalker_path,
+        "--driven_audio",
+        input_audio,
+        "--source_image",
+        input_image,
+        "--result_dir",
+        output_dir,
+        "--enhancer",
+        "gfpgan",
+        "--still",
+        "--preprocess",
+        "full",
     ]
+
     subprocess.run(command, check=True)
-    # SadTalker saves result as result.mp4; rename it to our unique path
+
     default_output = os.path.join(output_dir, "result.mp4")
     if os.path.exists(default_output):
         os.replace(default_output, output_path)

--- a/tests/test_sadtalker_command.py
+++ b/tests/test_sadtalker_command.py
@@ -13,7 +13,8 @@ def test_command_uses_sys_executable(monkeypatch, tmp_path):
     monkeypatch.setattr(si.os.path, 'exists', lambda path: False)
     monkeypatch.setattr(si.os, 'replace', lambda src, dst: None)
 
-    si.generate_video('img.png', 'audio.wav', output_dir=str(tmp_path))
+    output_path = tmp_path / "out.mp4"
+    si.generate_video('img.png', 'audio.wav', output_path=str(output_path))
 
     expected_sadtalker = os.path.join(os.path.dirname(si.__file__), '..', 'SadTalker-main', 'inference.py')
     expected_command = [


### PR DESCRIPTION
## Summary
- fix path detection for SadTalker and invoke with `sys.executable`
- compute output directory from `output_path`
- adjust test to new argument name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_683f0bb28c7083248c4706e96c274202