### PR TITLE
Refactor TTS generation

### DIFF
--- a/tts/xtts_infer.py
+++ b/tts/xtts_infer.py
@@ -1,5 +1,6 @@
 from TTS.api import TTS
 import os
+import uuid
 
 
 # Модель инициализируется лениво при первом вызове generate_tts
@@ -7,7 +8,8 @@ tts_model = None
 
 
 
-def generate_tts(text, speaker_wav_path, language, output_dir="assets"):
+def generate_tts(text: str, speaker_wav_path: str | None, language: str,
+                 output_dir: str = "assets") -> str:
     """Generate speech from text and return path to the WAV file."""
     global tts_model
 
@@ -25,12 +27,4 @@ def generate_tts(text, speaker_wav_path, language, output_dir="assets"):
         language=language,
         file_path=output_path,
     )
-
-def generate_tts(text, speaker_wav_path, language, output_path="assets/tts.wav"):
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    tts.tts_to_file(text=text,
-                    speaker_wav=speaker_wav_path,
-                    language=language,
-                    file_path=output_path)
-
     return output_path


### PR DESCRIPTION
## Summary
- clean up `generate_tts`
- add missing `uuid` import
- remove duplicate implementation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_683f0bb12a808324baceddf92ff481da