### PR TITLE
Add Swagger integration note and root endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ celery -A backend.tasks worker --loglevel=info
 uvicorn backend.api:app --reload
 ```
 
+После запуска сервера откройте `http://localhost:8000/docs`, чтобы увидеть интерактивную документацию Swagger.
+
 ## Эндпоинты API
 
 Доступные маршруты описаны в Swagger UI по адресу `/docs`.

--- a/backend/api.py
+++ b/backend/api.py
@@ -12,7 +12,17 @@ def verify_api_key(api_key: str | None):
     if SECRET_KEY and api_key != SECRET_KEY:
         raise HTTPException(status_code=401, detail="Invalid API key")
 
-app = FastAPI()
+app = FastAPI(
+    title="Voice Video Generator API",
+    description="REST API для генерации видео с говорящим лицом. Swagger UI доступен по адресу /docs.",
+    version="1.0.0",
+)
+
+
+@app.get("/")
+async def read_root():
+    """Простой корневой эндпоинт с ссылкой на документацию."""
+    return {"message": "Добро пожаловать! Документация доступна по адресу /docs"}
 
 def _save_upload(upload: UploadFile, folder: str) -> str:
     os.makedirs(folder, exist_ok=True)


### PR DESCRIPTION
## Summary
- show intro message at the API root and configure FastAPI metadata
- mention how to access Swagger UI in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_683f10e18b8c83249aa589d2cd161a5b